### PR TITLE
docs: add development setup script and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Development Guidelines for Agents
+
+This repository contains a Rust crate. Contributions should maintain a consistent style and follow the rules outlined below.
+
+## Commit Message Standards
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+- Format: `type(scope): summary` e.g. `feat(parser): add new AST parser`.
+- Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`.
+- Use the imperative mood in the summary line and keep it under 72 characters.
+
+## Commit Sequencing
+- Break changes into logical, atomic commits.
+- Keep commits focused; unrelated changes require separate commits.
+- Order commits so that tests and lints pass at each step.
+
+## Pull Request Standards
+- Title should summarise the change using Conventional Commit style.
+- Description must include:
+  - **Summary**: high level overview of changes.
+  - **Testing**: commands run and their results.
+  - **Future Work**: optional notes on follow ups.
+
+## Code Housekeeping
+- Run `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` before committing.
+- Remove unused code and keep dependencies up to date.
+- Track technical debt in issue tracker when needed.
+
+## Architecture and Design
+- Document significant design decisions in `/docs/adr-<number>.md` using the [ADR format](https://adr.github.io/).
+- Keep modules focused; avoid large files with mixed concerns.
+- Public API changes require updates to documentation and examples.
+
+## Versioning
+- This crate follows [Semantic Versioning](https://semver.org/).
+- Increment:
+  - **MAJOR** for incompatible API changes.
+  - **MINOR** for backwards compatible functionality.
+  - **PATCH** for backwards compatible bug fixes.
+- Tags are of the form `vX.Y.Z`.
+
+## Changelog Maintenance
+- Update `CHANGELOG.md` for any externally visible change.
+- Use sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+- Keep an `Unreleased` section at the top.
+
+## Testing Standards
+- Prefer unit tests close to the code they test.
+- Use doctests for examples as seen in `src/`.
+- Ensure `cargo test` passes before pushing.
+
+## Documentation Standards
+- Keep `README.md` up to date with major changes.
+- Public items must have rustdoc comments.
+- Examples should compile as part of the test suite.
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 - Provides methods for element counting, access, and manipulation based on sign.
 - Integrates with user-defined types via the `Signable` trait.
 
+## Development Setup
+Run `./setup-dev.sh` once with internet to install Rust and fetch dependencies.
+
 ## Usage: Basic operations
 
 ```rust

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Setup script for SignVec development environment
+# Installs Rust toolchain and fetches dependencies for offline work
+
+main() {
+    echo "[setup-dev] Starting setup..."
+
+    if ! command -v curl >/dev/null; then
+        echo "[setup-dev] Installing curl"
+        apt-get update && apt-get install -y curl
+    fi
+
+    echo "[setup-dev] Installing build essentials"
+    apt-get update && apt-get install -y build-essential pkg-config git ca-certificates
+
+    if ! command -v rustup >/dev/null; then
+        echo "[setup-dev] Installing rustup and Rust toolchain"
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+        export PATH="$HOME/.cargo/bin:$PATH"
+    else
+        echo "[setup-dev] rustup already installed"
+    fi
+
+    source "$HOME/.cargo/env"
+
+    echo "[setup-dev] Ensuring stable toolchain with components"
+    rustup toolchain install stable --profile minimal
+    rustup component add rustfmt clippy
+
+    echo "[setup-dev] Generating Cargo.lock for reproducibility"
+    cargo generate-lockfile
+
+    echo "[setup-dev] Fetching dependencies"
+    cargo fetch --locked
+
+    echo "[setup-dev] Building crates to populate cache"
+    cargo test --locked --no-run
+    cargo bench --bench signvec --no-run || true
+
+    echo "[setup-dev] Setup complete. Rust is located at $(rustc --version)"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `setup-dev.sh` for preparing an offline dev environment
- document how to run the script in README
- define contribution standards in new `AGENTS.md`

## Testing
- `bash setup-dev.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684947a15e5c832b8912d87c42a2e77d